### PR TITLE
fix default master journal type setting

### DIFF
--- a/pkg/ddc/alluxio/transform_optimization.go
+++ b/pkg/ddc/alluxio/transform_optimization.go
@@ -66,7 +66,11 @@ func (e *AlluxioEngine) optimizeDefaultProperties(runtime *datav1alpha1.AlluxioR
 	setDefaultProperties(runtime, value, "alluxio.user.file.passive.cache.enabled", "false")
 	setDefaultProperties(runtime, value, "alluxio.user.block.avoid.eviction.policy.reserved.size.bytes", "2GB")
 	setDefaultProperties(runtime, value, "alluxio.master.journal.folder", "/journal")
-	setDefaultProperties(runtime, value, "alluxio.master.journal.type", "UFS")
+	if value.Master.Replicas > 1 {
+		setDefaultProperties(runtime, value, "alluxio.master.journal.type", "EMBEDDED")
+	} else {
+		setDefaultProperties(runtime, value, "alluxio.master.journal.type", "UFS")
+	}
 	setDefaultProperties(runtime, value, "alluxio.user.block.master.client.pool.gc.threshold", "10min")
 	setDefaultProperties(runtime, value, "alluxio.user.file.master.client.threads", "1024")
 	setDefaultProperties(runtime, value, "alluxio.user.block.master.client.threads", "1024")


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

In default setting, the `alluxio.master.journal.type` will set to `UFS`, causing the HA mode fail. Now we change the default setting according to the master replicas.

### Ⅳ. Describe how to verify it

Deploy a HA alluxio dataset,  delete the leading master pod, you will see: 
* Without this commit, the leading master will always be master-0 if it exists, and the workers will lost when the old leading master restart.
* With the commit, everything works well.
